### PR TITLE
Symlink index.md -> README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# pelias-doc
+index.md

--- a/transition.md
+++ b/transition.md
@@ -1,0 +1,1 @@
+008-transition-from-beta.md


### PR DESCRIPTION
MKDocs generates project documentation from an `index.md` file. Github defaults to a README.md to display on the project page. Lets make these two be friends.

The good news is Github will happily read an aliased README.me, so when we turn on MKdocs, we get the best of both worlds.

![R. Kelly * Jay-Z - The Best of Both Worlds album cover](http://ring.cdandlp.com/palprod/photo_grande/115297317.png)