### PR TITLE
Remove section on debouncing autocomplete

### DIFF
--- a/autocomplete.md
+++ b/autocomplete.md
@@ -4,8 +4,6 @@ If you are building an end-user application, you can enable `/autocomplete` alon
 
 To get started with autocomplete, you need only a developer key and a `text` parameter,  representing what a user has typed into your application so far.  Optionally, you can specify the number of results to return and where the search should be centered.  
 
-In the interest of not overloading Mapzen search, please allow a reasonable amount of time between user keystrokes before querying.  That is, a fast typer may have only milliseconds between keystrokes.  Querying Mapzen search on every keystroke would result in a number of requests that would not respond in time to display results before the next request was sent.  A good rule of thumb is to allow a delay of `x` milliseconds before sending the entered text.  
-
 ### Size
 
 The default number of results that an autocomplete request will return is 10, but this can be overridden using the `size` parameter.  The default value for `size` is `10` and the maximum value is `40`. Specifying a value greater than `40` will override to `40` and return a warning in the response metadata.  


### PR DESCRIPTION
We are enabling Fastly which should help with performance, and in any
case I'd rather not lower performance expectations too much in the docs
themselves.