### PR TITLE
added in note about new domain and v1 to transition documentation

### DIFF
--- a/transition-from-beta.md
+++ b/transition-from-beta.md
@@ -23,6 +23,13 @@ Your API usage limits are displayed in the HTTP headers of any API call, such as
 X-ApiaxleProxy-Qpd-Left:4828
 X-ApiaxleProxy-Qps-Left:4
 ```
+## Changes to Domain + URL Structure:
+Mapzen Search is now hosted on the `search.mapzen.com` domain. The former domain, `pelias.mapzen.com` has been deprecated. To take advantage of the full v1 api, you must use the `search.mapzen.com` endpoint.
+
+Additionally, all endpoints are now under the `/v1` namespace. For example, the full URI to the `/reverse` endpoint is now `https://search.mapzen.com/v1/reverse`.
+
+Requests going to `pelias.mapzen.com` will continue to work until the end of November, 2015, at which point we will be disabling the servers that handle pre-v1 requests.
+
 
 ## Changes to response document
 The response document is still plain, vanilla GeoJSON. Dots will still show up without a problem! Take a look at the [specification document](https://github.com/pelias/geocodejson-spec/blob/master/draft/README.md) or the [sample response](https://github.com/pelias/geocodejson-spec/blob/master/sample.geo.json?short_path=7cdb999) for further details.

--- a/transition-from-beta.md
+++ b/transition-from-beta.md
@@ -23,12 +23,12 @@ Your API usage limits are displayed in the HTTP headers of any API call, such as
 X-ApiaxleProxy-Qpd-Left:4828
 X-ApiaxleProxy-Qps-Left:4
 ```
-## Changes to Domain + URL Structure:
-Mapzen Search is now hosted on the `search.mapzen.com` domain. The former domain, `pelias.mapzen.com` has been deprecated. To take advantage of the full v1 api, you must use the `search.mapzen.com` endpoint.
+## Changes to domain and URL structure
+Mapzen Search is now hosted on the `search.mapzen.com` domain. The former domain, `pelias.mapzen.com` has been deprecated. To take advantage of the full v1 API, you must use the `search.mapzen.com` endpoint.
 
 Additionally, all endpoints are now under the `/v1` namespace. For example, the full URI to the `/reverse` endpoint is now `https://search.mapzen.com/v1/reverse`.
 
-Requests going to `pelias.mapzen.com` will continue to work until the end of November, 2015, at which point we will be disabling the servers that handle pre-v1 requests.
+Requests going to `pelias.mapzen.com` will continue to work until the end of November, 2015, at which point the servers handling pre-v1 requests will be disabled.
 
 
 ## Changes to response document


### PR DESCRIPTION
As the Mapillary folks noted, we didn't explicitly mention the new domain nor the /v1/ URL namespace in this document. Whoops.