### PR TITLE
add documentation about the rate limiter behaviour

### DIFF
--- a/api-keys-rate-limits.md
+++ b/api-keys-rate-limits.md
@@ -19,7 +19,7 @@ Mapzen Search allows you a maximum of:
 If you need more capacity, contact [search@mapzen.com](mailto:search@mapzen.com). You can also set up your own instance of [Pelias](https://github.com/pelias/pelias), which has access to the same data used in Mapzen Search.
 
 ## Failing to provide an `api_key`
-If you fail to supply the `api_key` parameter the service will respond with the status code `403 Forbidden`:
+If you fail to supply the `api_key` parameter, the service will respond with the status code `403 Forbidden`:
 ```bash
 {
   "meta": {
@@ -36,7 +36,7 @@ If you fail to supply the `api_key` parameter the service will respond with the 
 ```
 
 ## Exceeding your limits
-If you exceed your limits the service will respond with the status code `429 Too Many Requests`:
+If you exceed your limits, the service will respond with the status code `429 Too Many Requests`:
 ```bash
 {
   "meta": {

--- a/api-keys-rate-limits.md
+++ b/api-keys-rate-limits.md
@@ -18,5 +18,39 @@ Mapzen Search allows you a maximum of:
 
 If you need more capacity, contact [search@mapzen.com](mailto:search@mapzen.com). You can also set up your own instance of [Pelias](https://github.com/pelias/pelias), which has access to the same data used in Mapzen Search.
 
+## Failing to provide an `api_key`
+If you fail to supply the `api_key` parameter the service will respond with the status code `403 Forbidden`:
+```bash
+{
+  "meta": {
+    "version": 1,
+    "status_code": 403
+  },
+  "results": {
+    "error": {
+      "type": "KeyError",
+      "message": "No api_key specified."
+    }
+  }
+}
+```
+
+## Exceeding your limits
+If you exceed your limits the service will respond with the status code `429 Too Many Requests`:
+```bash
+{
+  "meta": {
+    "version": 1,
+    "status_code": 429
+  },
+  "results": {
+    "error": {
+      "type": "QpsExceededError",
+      "message": "Queries per second exceeded: Queries exceeded (6 allowed)."
+    }
+  }
+}
+```
+
 ## Security
 Mapzen Search works over HTTPS, in addition to HTTP. You are strongly encouraged to use HTTPS for all requests, especially for queries involving potentially sensitive information, such as a user's location or search query.


### PR DESCRIPTION
add documentation about the rate limiter behaviour

resolves: https://github.com/pelias/pelias-doc/issues/50

review please @rmglennon (this will be the same across all mapzen services)

**note:** viewing the error messages in your browser will render them as `XML`, this is due to most browsers sending a header such as `Accept:text/html,application/xhtml+xml,application/xml`, if you want to see `JSON` you'll need to send a header such as `Accept:application/json` instead