### PR TITLE
Revises Geonames abbreviation

### DIFF
--- a/search.md
+++ b/search.md
@@ -292,7 +292,7 @@ The search examples so far have returned a mix of results from all the data sour
 | [OpenStreetMap](http://www.openstreetmap.org/) | `openstreetmap` | `osm` |
 | [OpenAddresses](http://openaddresses.io/) | `openaddresses` | `oa` |
 | [Quattroshapes](http://quattroshapes.com/) | `quattroshapes` | `qs` |
-| [GeoNames](http://www.geonames.org/) | `geonames` | `ga` |
+| [GeoNames](http://www.geonames.org/) | `geonames` | `gn` |
 
 If you use the `sources` parameter, you can choose which of these data sources to include in your search. So if you're only interested in finding a YMCA in data from OpenAddresses, for example, you can build a query specifying that data source.
 


### PR DESCRIPTION
Fixes geonames abbreviation (is `gn`, but was written `ga` in one document).

Good catch by @msmollin in pelias/pelias#261

Fixes pelias/pelias#261