### PR TITLE
Make example query links work

### DIFF
--- a/add-search-to-a-map.md
+++ b/add-search-to-a-map.md
@@ -189,13 +189,13 @@ At this point, you have a map! You should see a map with OpenStreetMap tiles, zo
 So far, you have referenced the necessary files, initialized Leaflet with a map container on the page, and added data to the map. Now, you are ready to add the Search box from the Mapzen Search plug-in.
 
 1. Go back to the https://mapzen.com/developers page and copy your API key to the clipboard.
-2. Inside the same `<script>` tag, start a new line after the `}).addTo(map);` line. Initialize a search box with the following code and your own API key substituted for the placeholder text of `search-hnopfLZ`.
+2. Inside the same `<script>` tag, start a new line after the `}).addTo(map);` line. Initialize a search box with the following code and your own API key substituted for the placeholder text of `search-xxxxxx`.
 
     ```js
-    var geocoder = L.control.geocoder('search-hnopfLZ').addTo(map);
+    var geocoder = L.control.geocoder('search-xxxxxx').addTo(map);
     ```
 
-    The `search-hnopfLZ` text is the Mapzen Search API key; paste your own API key inside the single quotes.
+    The `search-xxxxxx` text is the Mapzen Search API key; paste your own API key inside the single quotes.
 
 3. Save your edits and refresh the browser. You should see a small magnifying glass icon in the left corner, near the zoom controls.
 
@@ -216,7 +216,7 @@ Your `<body>` section should look like this:
     L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
       attribution: '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
     }).addTo(map);
-    var geocoder = L.control.geocoder('search-hnopfLZ').addTo(map);
+    var geocoder = L.control.geocoder('search-xxxxxx').addTo(map);
   </script>
 </body>
 [...]
@@ -273,7 +273,7 @@ You can refer to this HTML if you want to review your work or troubleshoot an er
     }).addTo(map);
 
     //Use your own API key in place of this one. Get a key at mapzen.com/developers.
-    var geocoder = L.control.geocoder('search-hnopfLZ').addTo(map);
+    var geocoder = L.control.geocoder('search-xxxxxx').addTo(map);
   </script>
 </body>
 </html>

--- a/add-search-to-a-map.md
+++ b/add-search-to-a-map.md
@@ -189,13 +189,13 @@ At this point, you have a map! You should see a map with OpenStreetMap tiles, zo
 So far, you have referenced the necessary files, initialized Leaflet with a map container on the page, and added data to the map. Now, you are ready to add the Search box from the Mapzen Search plug-in.
 
 1. Go back to the https://mapzen.com/developers page and copy your API key to the clipboard.
-2. Inside the same `<script>` tag, start a new line after the `}).addTo(map);` line. Initialize a search box with the following code and your own API key substituted for the placeholder text of `search-xxxxxx`.
+2. Inside the same `<script>` tag, start a new line after the `}).addTo(map);` line. Initialize a search box with the following code and your own API key substituted for the placeholder text of `search-hnopfLZ`.
 
     ```js
-    var geocoder = L.control.geocoder('search-xxxxxx').addTo(map);
+    var geocoder = L.control.geocoder('search-hnopfLZ').addTo(map);
     ```
 
-    The `search-xxxxxx` text is the Mapzen Search API key; paste your own API key inside the single quotes.
+    The `search-hnopfLZ` text is the Mapzen Search API key; paste your own API key inside the single quotes.
 
 3. Save your edits and refresh the browser. You should see a small magnifying glass icon in the left corner, near the zoom controls.
 
@@ -216,7 +216,7 @@ Your `<body>` section should look like this:
     L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
       attribution: '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
     }).addTo(map);
-    var geocoder = L.control.geocoder('search-xxxxxx').addTo(map);
+    var geocoder = L.control.geocoder('search-hnopfLZ').addTo(map);
   </script>
 </body>
 [...]
@@ -272,8 +272,8 @@ You can refer to this HTML if you want to review your work or troubleshoot an er
       attribution: '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
     }).addTo(map);
 
-    //Use your own API key in place of search-xxxxxx. Get a key at mapzen.com/developers.
-    var geocoder = L.control.geocoder('search-xxxxxx').addTo(map);
+    //Use your own API key in place of this one. Get a key at mapzen.com/developers.
+    var geocoder = L.control.geocoder('search-hnopfLZ').addTo(map);
   </script>
 </body>
 </html>

--- a/autocomplete.md
+++ b/autocomplete.md
@@ -19,7 +19,7 @@ To focus your search based upon a geographical area, such as the center of the u
 From San Francisco:
 
 >
-[/v1/autocomplete?api_key=search-hnopfLZ&focus.point.lat=37.7&focus.point.lon=-122.4&text=union square](https://search.mapzen.com/v1/autocomplete?api_key=search-hnopfLZ&focus.point.lat=37.7&focus.point.lon=-122.4&text=union square)
+[/v1/autocomplete?api_key=search-hnopfLZ&__focus.point.lat=37.7&focus.point.lon=-122.4&text=union square__](https://search.mapzen.com/v1/autocomplete?api_key=search-hnopfLZ&focus.point.lat=37.7&focus.point.lon=-122.4&text=union square)
 
 ```
 1)	Union Square, San Francisco County, CA
@@ -29,7 +29,7 @@ From San Francisco:
 From New York City:
 
 >
-[/v1/autocomplete?api_key=search-hnopfLZ&focus.point.lat=40.7&focus.point.lon=-73.9&text=union square](https://search.mapzen.com/v1/autocomplete?api_key=search-hnopfLZ&focus.point.lat=40.7&focus.point.lon=-73.9&text=union square)
+[/v1/autocomplete?api_key=search-hnopfLZ&__focus.point.lat=40.7&focus.point.lon=-73.9&text=union square__](https://search.mapzen.com/v1/autocomplete?api_key=search-hnopfLZ&focus.point.lat=40.7&focus.point.lon=-73.9&text=union square)
 
 ```
 1)	Union Square, New York County, NY
@@ -38,7 +38,7 @@ From New York City:
 
 The `/autocomplete` endpoint can promote nearby results to the top of the list, while still allowing important matches from farther away to be visible. For example, searching `hard rock cafe` with a focus on Berlin:
 
-> [/v1/autocomplete?api_key=search-hnopfLZ&focus.point.lat=52.5&focus.point.lon=13.3&text=hard rock cafe](https://search.mapzen.com/v1/autocomplete?api_key=search-hnopfLZ&focus.point.lat=52.5&focus.point.lon=13.3&text=hard rock cafe)
+> [/v1/autocomplete?api_key=search-hnopfLZ&__focus.point.lat=52.5&focus.point.lon=13.3&text=hard rock cafe__](https://search.mapzen.com/v1/autocomplete?api_key=search-hnopfLZ&focus.point.lat=52.5&focus.point.lon=13.3&text=hard rock cafe)
 
 with `focus.point` you will find the Berlin restaurant first:
 ```
@@ -65,7 +65,7 @@ The `sources` parameter allows you to specify from which data sources you'd like
 * `geonames` or `gn`
 * `whosonfirst` or `wof`
 
-> [/v1/autocomplete?api_key=search-hnopfLZ&sources=openaddresses&text=pennsylvania](https://search.mapzen.com/v1/autocomplete?api_key=search-hnopfLZ&sources=openaddresses&text=pennsylvania)
+> [/v1/autocomplete?api_key=search-hnopfLZ&__sources=openaddresses__&text=pennsylvania](https://search.mapzen.com/v1/autocomplete?api_key=search-hnopfLZ&sources=openaddresses&text=pennsylvania)
 
 with `sources=openaddresses` you will only find addresses on Pennsylvania Ave or Street:
 ```
@@ -99,7 +99,7 @@ The type of record is referred to as its `layer`. All records are indexed into t
 
 You can also refer to all the administrative hierarchy layers with a single alias, `coarse`.
 
-> [/v1/autocomplete?api_key=search-hnopfLZ&layers=coarse&text=starbuck](https://search.mapzen.com/v1/autocomplete?api_key=search-hnopfLZ&layers=coarse&text=starbuck)
+> [/v1/autocomplete?api_key=search-hnopfLZ&__layers=coarse__&text=starbuck](https://search.mapzen.com/v1/autocomplete?api_key=search-hnopfLZ&layers=coarse&text=starbuck)
 
 with `layers=coarse` you will see only administrative areas with names containing Starbuck
 

--- a/autocomplete.md
+++ b/autocomplete.md
@@ -18,7 +18,8 @@ To focus your search based upon a geographical area, such as the center of the u
 
 From San Francisco:
 
-> /v1/autocomplete?api_key=search-XXXXXXX&focus.point.lat=37.7&focus.point.lon=-122.4&text=union square
+>
+[/v1/autocomplete?api_key=search-hnopfLZ&focus.point.lat=37.7&focus.point.lon=-122.4&text=union square](https://search.mapzen.com/v1/autocomplete?api_key=search-hnopfLZ&focus.point.lat=37.7&focus.point.lon=-122.4&text=union square)
 
 ```
 1)	Union Square, San Francisco County, CA
@@ -27,7 +28,8 @@ From San Francisco:
 
 From New York City:
 
-> /v1/autocomplete?api_key=search-XXXXXXX&focus.point.lat=40.7&focus.point.lon=-73.9&text=union square
+>
+[/v1/autocomplete?api_key=search-hnopfLZ&focus.point.lat=40.7&focus.point.lon=-73.9&text=union square](https://search.mapzen.com/v1/autocomplete?api_key=search-hnopfLZ&focus.point.lat=40.7&focus.point.lon=-73.9&text=union square)
 
 ```
 1)	Union Square, New York County, NY
@@ -36,7 +38,7 @@ From New York City:
 
 The `/autocomplete` endpoint can promote nearby results to the top of the list, while still allowing important matches from farther away to be visible. For example, searching `hard rock cafe` with a focus on Berlin:
 
-> /v1/autocomplete?api_key=search-XXXXXXX&focus.point.lat=52.5&focus.point.lon=13.3&text=hard rock cafe
+> [/v1/autocomplete?api_key=search-hnopfLZ&focus.point.lat=52.5&focus.point.lon=13.3&text=hard rock cafe](https://search.mapzen.com/v1/autocomplete?api_key=search-hnopfLZ&focus.point.lat=52.5&focus.point.lon=13.3&text=hard rock cafe)
 
 with `focus.point` you will find the Berlin restaurant first:
 ```
@@ -52,7 +54,7 @@ without `focus.point` you will find the most popular restaurants first:
 
 ## Filters
 
-You can filter the results in several ways: the original data source and/or the type of record. 
+You can filter the results in several ways: the original data source and/or the type of record.
 
 ### Sources
 
@@ -63,7 +65,7 @@ The `sources` parameter allows you to specify from which data sources you'd like
 * `geonames` or `gn`
 * `whosonfirst` or `wof`
 
-> /v1/autocomplete?api_key=search-XXXXXXX&sources=openaddresses&text=pennsylvania
+> [/v1/autocomplete?api_key=search-hnopfLZ&sources=openaddresses&text=pennsylvania](https://search.mapzen.com/v1/autocomplete?api_key=search-hnopfLZ&sources=openaddresses&text=pennsylvania)
 
 with `sources=openaddresses` you will only find addresses on Pennsylvania Ave or Street:
 ```
@@ -80,7 +82,7 @@ without `sources=openaddresses` you will find the most popular Pennsylvanias fir
 ```
 
 ### Layers
-We refer to the type of record as its `layer`. We index all records into the following layers
+The type of record is referred to as its `layer`. All records are indexed into the following layers:
 
 * `venue`
 * `address`
@@ -95,9 +97,9 @@ We refer to the type of record as its `layer`. We index all records into the fol
 * `region`
 * `country`
 
-We also allow users to refer to all the administrative hierarchy layers with a single alias, `coarse`.
+You can also refer to all the administrative hierarchy layers with a single alias, `coarse`.
 
-> /v1/autocomplete?api_key=search-XXXXXXX&layers=coarse&text=starbuck
+> [/v1/autocomplete?api_key=search-hnopfLZ&layers=coarse&text=starbuck](https://search.mapzen.com/v1/autocomplete?api_key=search-hnopfLZ&layers=coarse&text=starbuck)
 
 with `layers=coarse` you will see only administrative areas with names containing Starbuck
 

--- a/place.md
+++ b/place.md
@@ -9,13 +9,13 @@ These `gid` strings should not be built manually, but rather used directly as-is
 
 For example, this `/place` query looks up the Eiffel Tower in OpenStreetMap (OSM):
 
-https://search.mapzen.com/v1/place?api_key=search-hnopfLZ&ids=openstreetmap:venue:way:5013364
+> [/v1/place?api_key=search-hnopfLZ&ids=openstreetmap:venue:way:5013364](https://search.mapzen.com/v1/place?api_key=search-hnopfLZ&ids=openstreetmap:venue:way:5013364)
 
 ## Search for multiple places in a query
 
 To search for more than one `/place` in a request, join multiple values together and separate them with a comma. For example, this `/place` query looks up the Eiffel Tower in OpenStreetMap and the borough of Manhattan in Who's on First:
 
-https://search.mapzen.com/v1/place?api_key=search-hnopfLZ&ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771
+> [/v1/place?api_key=search-hnopfLZ&ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771](https://search.mapzen.com/v1/place?api_key=search-hnopfLZ&ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771)
 
 The results are returned in the order requested.
 

--- a/place.md
+++ b/place.md
@@ -9,13 +9,13 @@ These `gid` strings should not be built manually, but rather used directly as-is
 
 For example, this `/place` query looks up the Eiffel Tower in OpenStreetMap (OSM):
 
-> [/v1/place?api_key=search-hnopfLZ&ids=openstreetmap:venue:way:5013364](https://search.mapzen.com/v1/place?api_key=search-hnopfLZ&ids=openstreetmap:venue:way:5013364)
+> [/v1/place?api_key=search-hnopfLZ&__ids=openstreetmap:venue:way:5013364__](https://search.mapzen.com/v1/place?api_key=search-hnopfLZ&ids=openstreetmap:venue:way:5013364)
 
 ## Search for multiple places in a query
 
 To search for more than one `/place` in a request, join multiple values together and separate them with a comma. For example, this `/place` query looks up the Eiffel Tower in OpenStreetMap and the borough of Manhattan in Who's on First:
 
-> [/v1/place?api_key=search-hnopfLZ&ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771](https://search.mapzen.com/v1/place?api_key=search-hnopfLZ&ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771)
+> [/v1/place?api_key=search-hnopfLZ&__ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771__](https://search.mapzen.com/v1/place?api_key=search-hnopfLZ&ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771)
 
 The results are returned in the order requested.
 

--- a/place.md
+++ b/place.md
@@ -9,13 +9,13 @@ These `gid` strings should not be built manually, but rather used directly as-is
 
 For example, this `/place` query looks up the Eiffel Tower in OpenStreetMap (OSM):
 
-https://search.mapzen.com/v1/place?api_key=search-XXXXXXX&ids=openstreetmap:venue:way:5013364
+https://search.mapzen.com/v1/place?api_key=search-hnopfLZ&ids=openstreetmap:venue:way:5013364
 
 ## Search for multiple places in a query
 
 To search for more than one `/place` in a request, join multiple values together and separate them with a comma. For example, this `/place` query looks up the Eiffel Tower in OpenStreetMap and the borough of Manhattan in Who's on First:
 
-https://search.mapzen.com/v1/place?api_key=search-XXXXXXX&ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771
+https://search.mapzen.com/v1/place?api_key=search-hnopfLZ&ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771
 
 The results are returned in the order requested.
 

--- a/response.md
+++ b/response.md
@@ -99,8 +99,8 @@ By default, Mapzen Search results 10 places, unless otherwise specified. If you 
 | `text` | YMCA |
 | `size` | 1 |
 
-> [/v1/search?api_key=search-XXXXXXX&text=YMCA&___size=1___](https://search.mapzen.com/v1/search?api_key=search-XXXXXXX&text=YMCA&size=1)
+> [/v1/search?api_key=search-hnopfLZ&text=YMCA&___size=1___](https://search.mapzen.com/v1/search?api_key=search-hnopfLZ&text=YMCA&size=1)
 
 If you want 25 results, you can build the query where `size` is 25.
 
-> [/v1/search?api_key=search-XXXXXXX&text=YMCA&___size=25___](https://search.mapzen.com/v1/search?api_key=search-XXXXXXX&text=YMCA&size=25)
+> [/v1/search?api_key=search-hnopfLZ&text=YMCA&___size=25___](https://search.mapzen.com/v1/search?api_key=search-hnopfLZ&text=YMCA&size=25)

--- a/reverse.md
+++ b/reverse.md
@@ -14,7 +14,7 @@ With reverse geocoding with Mapzen Search, you can look up all sorts of informat
 
 To get started with reverse geocoding, you need a [developer API key](https://mapzen.com/developers) and a latitude, longitude pair in decimal degrees specified with the parameters `point.lat` and `point.lon`, respectively.  For example, the Eiffel Tower in Paris, France, is located at `48.858268,2.294471`. The reverse geocode query for this would be:
 
->[/v1/reverse?api_key=search-XXXXXXX&___point.lat=48.858268___&___point.lon=2.294471___](https://search.mapzen.com/v1/reverse?api_key=search-XXXXXXX&point.lat=48.858268&point.lon=2.294471)
+>[/v1/reverse?api_key=search-hnopfLZ&___point.lat=48.858268___&___point.lon=2.294471___](https://search.mapzen.com/v1/reverse?api_key=search-hnopfLZ&point.lat=48.858268&point.lon=2.294471)
 
 Notice that the first result is the Eiffel Tower (well, _Tour Eiffel_). The output is the standard GeoJSON format.
 
@@ -36,7 +36,7 @@ Parameter | Type | Required | Default | Example
 
 A basic parameter for filtering is `size`, which is used to limit the number of results returned. In the earlier request that returned the Eiffel Tower (or 'Tour Eiffel', to be exact), notice that other results were returned including "Bureau de Gustave Eiffel" (a museum) and "Le Jules Verne" (a restaurant). To limit a reverse geocode to only the first result, pass the `size` parameter:
 
->[/v1/reverse?api_key=search-XXXXXXX&point.lat=48.858268&point.lon=2.294471&___size=1___](https://search.mapzen.com/v1/reverse?api_key=search-XXXXXXX&point.lat=48.858268&point.lon=2.294471&size=1)
+>[/v1/reverse?api_key=search-hnopfLZ&point.lat=48.858268&point.lon=2.294471&___size=1___](https://search.mapzen.com/v1/reverse?api_key=search-hnopfLZ&point.lat=48.858268&point.lon=2.294471&size=1)
 
 The default value for `size` is `10` and the maximum value is `40`. Specifying a value greater than `40` will override to `40` and return a warning in the response metadata.
 
@@ -51,7 +51,7 @@ By default, reverse geocoding returns results from any [data source](data-source
 | [Who's on First](https://whosonfirst.mapzen.com) | `whosonfirst` | `wof` |
 | [GeoNames](http://www.geonames.org/) | `geonames` | `gn` |
 
->[/v1/reverse?api_key=search-XXXXXXX&point.lat=48.858268&point.lon=2.294471&___sources=osm___](https://search.mapzen.com/v1/reverse?api_key=search-XXXXXXX&point.lat=48.858268&point.lon=2.294471&sources=osm)
+>[/v1/reverse?api_key=search-hnopfLZ&point.lat=48.858268&point.lon=2.294471&___sources=osm___](https://search.mapzen.com/v1/reverse?api_key=search-hnopfLZ&point.lat=48.858268&point.lon=2.294471&sources=osm)
 
 ### Filter by layers (data type)
 
@@ -70,13 +70,13 @@ Without specifying further, reverse geocoding doesn't restrict results to a part
 |`coarse`|alias for simultaneously using `country`, `region`, `county`, `locality`, `localadmin`, and `neighbourhood`|
 
 
->[/v1/reverse?api_key=search-XXXXXXX&point.lat=48.858268&point.lon=2.294471&___layers=locality___](https://search.mapzen.com/v1/reverse?api_key=search-XXXXXXX&point.lat=48.858268&point.lon=2.294471&layers=locality)
+>[/v1/reverse?api_key=search-hnopfLZ&point.lat=48.858268&point.lon=2.294471&___layers=locality___](https://search.mapzen.com/v1/reverse?api_key=search-hnopfLZ&point.lat=48.858268&point.lon=2.294471&layers=locality)
 
 ### Filter by country
 
 If you are performing a reverse geocode near a country boundary, and are only interested in results from one country and not the other, you can specify a country code. You can set the `boundary.country` parameter value to the alpha-2 or alpha-3 [ISO-3166 country code](https://en.wikipedia.org/wiki/ISO_3166-1). For example, the latitude,longitude pair `47.270521,9.530846` is on the boundary of Austria, Liechtenstein, and Switzerland. Without specifying a `boundary.country`, the first 10 results returned may come from all three countries. By including `boundary.country=LIE`, all 10 results will be from Liechtenstein. Here's the request in action:
 
->[/v1/reverse?api_key=search-XXXXXXX&point.lat=47.270521&point.lon=9.530846&___boundary.country=LIE___](https://search.mapzen.com/v1/reverse?api_key=search-XXXXXXX&point.lat=47.270521&point.lon=9.530846&boundary.country=LIE)
+>[/v1/reverse?api_key=search-hnopfLZ&point.lat=47.270521&point.lon=9.530846&___boundary.country=LIE___](https://search.mapzen.com/v1/reverse?api_key=search-hnopfLZ&point.lat=47.270521&point.lon=9.530846&boundary.country=LIE)
 
 Note that `UK` is not a valid ISO 3166-1 alpha-2 country code.
 
@@ -98,16 +98,16 @@ Distance from `point.lat`/`point.lon` | Confidence score
 This section shows how the various parameters can be combined to form complex use cases.
 
 * All results near the Tower of London
->[/v1/reverse?api_key=search-XXXXXXX&point.lat=51.5081124&point.lon=-0.0759493](https://search.mapzen.com/v1/reverse?api_key=search-XXXXXXX&point.lat=51.5081124&point.lon=-0.0759493)
+>[/v1/reverse?api_key=search-hnopfLZ&point.lat=51.5081124&point.lon=-0.0759493](https://search.mapzen.com/v1/reverse?api_key=search-hnopfLZ&point.lat=51.5081124&point.lon=-0.0759493)
 
 * Only OpenStreetMap results near the Tower of London
->[/v1/reverse?api_key=search-XXXXXXX&point.lat=51.5081124&point.lon=-0.0759493&sources=osm](https://search.mapzen.com/v1/reverse?api_key=search-XXXXXXX&point.lat=51.5081124&point.lon=-0.0759493&sources=osm)
+>[/v1/reverse?api_key=search-hnopfLZ&point.lat=51.5081124&point.lon=-0.0759493&sources=osm](https://search.mapzen.com/v1/reverse?api_key=search-hnopfLZ&point.lat=51.5081124&point.lon=-0.0759493&sources=osm)
 
 * Only street addresses near the Tower of London
->[/v1/reverse?api_key=search-XXXXXXX&point.lat=51.5081124&point.lon=-0.0759493&layers=address](https://search.mapzen.com/v1/reverse?api_key=search-XXXXXXX&point.lat=51.5081124&point.lon=-0.0759493&layers=address)
+>[/v1/reverse?api_key=search-hnopfLZ&point.lat=51.5081124&point.lon=-0.0759493&layers=address](https://search.mapzen.com/v1/reverse?api_key=search-hnopfLZ&point.lat=51.5081124&point.lon=-0.0759493&layers=address)
 
 * Only OpenStreetMap street addresses near the Tower of London
->[/v1/reverse?api_key=search-XXXXXXX&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm](https://search.mapzen.com/v1/reverse?api_key=search-XXXXXXX&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm)
+>[/v1/reverse?api_key=search-hnopfLZ&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm](https://search.mapzen.com/v1/reverse?api_key=search-hnopfLZ&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm)
 
 * Only the first OpenStreetMap address near the Tower of London
->[/v1/reverse?api_key=search-XXXXXXX&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm&size=1](https://search.mapzen.com/v1/reverse?api_key=search-XXXXXXX&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm&size=1)
+>[/v1/reverse?api_key=search-hnopfLZ&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm&size=1](https://search.mapzen.com/v1/reverse?api_key=search-hnopfLZ&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm&size=1)

--- a/search.md
+++ b/search.md
@@ -305,7 +305,7 @@ If you use the `sources` parameter, you can choose which of these data sources t
 
 Because OpenAddresses is, as the name suggests, only address data, here's what you can expect to find:
 
-> * 0 Ymca, New Brunswick
+* 0 Ymca, New Brunswick
 * 0 Ymca Drive, Cary, NC
 * 14843 Ymca Lane, Cormorant, MN
 * 14660 Ymca Lane, Cormorant, MN

--- a/search.md
+++ b/search.md
@@ -23,7 +23,7 @@ In the simplest search, you can provide only one parameter, the text you want to
 
 For example, if you want to find a [YMCA](https://en.wikipedia.org/wiki/YMCA) facility, here's what you'd need to append to the base URL of the service, `search.mapzen.com`.
 
-> [/v1/search?api_key=search-XXXXXXX&___text=YMCA___](https://search.mapzen.com/v1/search?api_key=search-XXXXXXX&text=YMCA)
+> [/v1/search?api_key=search-hnopfLZ&___text=YMCA___](https://search.mapzen.com/v1/search?api_key=search-hnopfLZ&text=YMCA)
 
 Note the parameter values are set as follows:
 
@@ -38,7 +38,7 @@ If you are having trouble seeing the JSON in your browser, you can install a bro
 
 In the example above, you will find the name of each matched locations in a property named `'label'`. The top 10 labels returned were:
 
-> * YMCA, Bargoed Community, United Kingdom
+* YMCA, Bargoed Community, United Kingdom
 * YMCA, Nunspeet, Gelderland
 * YMCA, Belleville, IL
 * YMCA, Forest City, IA
@@ -51,7 +51,7 @@ In the example above, you will find the name of each matched locations in a prop
 
 Spelling matters, but not capitalization when performing a query with Mapzen Search. You can type `ymca`, `YMCA`, or even `yMcA`. See for yourself by comparing the results of the earlier search to the following:
 
-> [/v1/search?api_key=search-XXXXXXX&___text=yMcA___](https://search.mapzen.com/v1/search?api_key=search-XXXXXXX&text=yMcA)
+> [/v1/search?api_key=search-hnopfLZ&___text=yMcA___](https://search.mapzen.com/v1/search?api_key=search-hnopfLZ&text=yMcA)
 
 Note that the results are spread out throughout the world because you have not given your current location or provided any other geographic context in which to search.
 
@@ -65,12 +65,11 @@ By default, Mapzen Search results 10 places, unless otherwise specified. If you 
 | `text` | YMCA |
 | `size` | 1 |
 
-> [/v1/search?api_key=search-XXXXXXX&text=YMCA&___size=1___](https://search.mapzen.com/v1/search?api_key=search-XXXXXXX&text=YMCA&size=1)
+> [/v1/search?api_key=search-hnopfLZ&text=YMCA&___size=1___](https://search.mapzen.com/v1/search?api_key=search-hnopfLZ&text=YMCA&size=1)
 
 If you want 25 results, you can build the query where `size` is 25.
 
-> [/v1/search?api_key=search-XXXXXXX&text=YMCA&___size=25___](https://search.mapzen.com/v1/search?api_key=search-XXXXXXX&text=YMCA&size=25)
-
+> [/v1/search?api_key=search-hnopfLZ&text=YMCA&___size=25___](https://search.mapzen.com/v1/search?api_key=search-hnopfLZ&text=YMCA&size=25)
 
 ## Narrow your search
 
@@ -84,7 +83,7 @@ Sometimes your work might require that all the search results be from a particul
 
 Now, you want to search for YMCA again, but this time only in Great Britain. To do this, you will need to know that the alpha-3 code for Great Britain is GBR and set the parameters like this:
 
-> [/v1/search?api_key=search-XXXXXXX&text=YMCA&___boundary.country=GBR___](https://search.mapzen.com/v1/search?api_key=search-XXXXXXX&text=YMCA&boundary.country=GBR)
+> [/v1/search?api_key=search-hnopfLZ&text=YMCA&___boundary.country=GBR___](https://search.mapzen.com/v1/search?api_key=search-hnopfLZ&text=YMCA&boundary.country=GBR)
 
 | parameter | value |
 | :--- | :--- |
@@ -94,7 +93,7 @@ Now, you want to search for YMCA again, but this time only in Great Britain. To 
 
 Note that all the results are within Great Britain:
 
-> * YMCA, Bargoed Community, United Kingdom
+* YMCA, Bargoed Community, United Kingdom
 * YMCA, Orpington, Greater London
 * YMCA, Erdington, West Midlands
 * YMCA, Malvern CP, United Kingdom
@@ -107,11 +106,11 @@ Note that all the results are within Great Britain:
 
 If you try the same search request with different country codes, the results change to show YMCA locations within this region.
 
-> [/v1/search?api_key=search-XXXXXXX&text=YMCA&___boundary.country=USA___](https://search.mapzen.com/v1/search?api_key=search-XXXXXXX&text=YMCA&boundary.country=USA)
+> [/v1/search?api_key=search-hnopfLZ&text=YMCA&___boundary.country=USA___](https://search.mapzen.com/v1/search?api_key=search-hnopfLZ&text=YMCA&boundary.country=USA)
 
 Results in the United States:
 
-> * YMCA, Belleville, IL
+* YMCA, Belleville, IL
 * YMCA, Forest City, IA
 * YMCA, Fargo, ND
 * YMCA, Frisco, TX
@@ -130,9 +129,9 @@ To specify the boundary using a rectangle, you need latitude, longitude coordina
 
 For example, to find a YMCA within the state of Texas, you can set the `boundary.rect.*` parameter to values representing the bounding box around Texas: min_lon=-106.65 min_lat=25.84 max_lon=-93.51 max_lat=36.5
 
-  Tip: You can look up a bounding box for a known region with this [web tool](http://boundingbox.klokantech.com/).
+Tip: You can look up a bounding box for a known region with this [web tool](http://boundingbox.klokantech.com/).
 
- [/v1/search?api_key=search-XXXXXXX&text=YMCA&___boundary.rect.min_lat=25.84&boundary.rect.min_lon=-106.65&boundary.rect.max_lat=36.5&boundary.rect.max_lon=-93.51___](https://search.mapzen.com/v1/search?api_key=search-XXXXXXX&text=YMCA&boundary.rect.min_lat=25.84&boundary.rect.min_lon=-106.65&boundary.rect.max_lat=36.5&boundary.rect.max_lon=-93.51)
+> [/v1/search?api_key=search-hnopfLZ&text=YMCA&___boundary.rect.min_lat=25.84&boundary.rect.min_lon=-106.65&boundary.rect.max_lat=36.5&boundary.rect.max_lon=-93.51___](https://search.mapzen.com/v1/search?api_key=search-hnopfLZ&text=YMCA&boundary.rect.min_lat=25.84&boundary.rect.min_lon=-106.65&boundary.rect.max_lat=36.5&boundary.rect.max_lon=-93.51)
 
 | parameter | value |
 | :--- | :--- |
@@ -143,7 +142,7 @@ For example, to find a YMCA within the state of Texas, you can set the `boundary
 | `boundary.rect.max_lat` | 36.5 |
 | `boundary.rect.max_lon` | -93.51 |
 
-> * YMCA, Austin, TX
+* YMCA, Austin, TX
 * YMCA, Frisco, TX
 * Y.M.C.A, Fort Worth, TX
 * YMCA, Rockwall, TX
@@ -162,7 +161,7 @@ Sometimes you don't have a rectangle to work with, but rather you have a point o
 
 In this example, you want to find all YMCA locations within a 35-kilometer radius of a location in Ontario, Canada. This time, you can use the `boundary.circle.*` parameter group, where `boundary.circle.lat` and `boundary.circle.lon` is your location in Ontario and `boundary.circle.radius` is the acceptable distance from that location. Note that the `boundary.circle.radius` parameter is always specified in kilometers.
 
-> [/v1/search?api_key=search-XXXXXXX&text=YMCA&__boundary.circle.lon=-79.186484&boundary.circle.lat=43.818156&boundary.circle.radius=35__](https://search.mapzen.com/v1/search?api_key=search-XXXXXXX&text=YMCA&boundary.circle.lon=-79.186484&boundary.circle.lat=43.818156&boundary.circle.radius=35)
+> [/v1/search?api_key=search-hnopfLZ&text=YMCA&__boundary.circle.lon=-79.186484&boundary.circle.lat=43.818156&boundary.circle.radius=35__](https://search.mapzen.com/v1/search?api_key=search-hnopfLZ&text=YMCA&boundary.circle.lon=-79.186484&boundary.circle.lat=43.818156&boundary.circle.radius=35)
 
 | parameter | value |
 | :--- | :--- |
@@ -174,7 +173,7 @@ In this example, you want to find all YMCA locations within a 35-kilometer radiu
 
 You can see the results have fewer than the standard 10 items because there are not that many YMCA locations in the specified radius:
 
-> * YMCA, Toronto, Ontario
+* YMCA, Toronto, Ontario
 * YMCA, Markham, Ontario
 * YMCA, Toronto, Ontario
 * Metro Central YMCA, Toronto, Ontario
@@ -198,7 +197,7 @@ By specifying a `focus.point`, nearby places will be scored higher depending on 
 
 To find YMCA again, but this time near a specific coordinate location (representing the Sydney Opera House) in Sydney, Australia, use `focus.point`.
 
-> [/v1/search?api_key=search-XXXXXXX&text=YMCA&___focus.point.lat=-33.856680&focus.point.lon=151.215281___](https://search.mapzen.com/v1/search?api_key=search-XXXXXXX&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281)
+> [/v1/search?api_key=search-hnopfLZ&text=YMCA&___focus.point.lat=-33.856680&focus.point.lon=151.215281___](https://search.mapzen.com/v1/search?api_key=search-hnopfLZ&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281)
 
 | parameter | value |
 | :--- | :--- |
@@ -209,7 +208,7 @@ To find YMCA again, but this time near a specific coordinate location (represent
 
 Looking at the results, you can see that the few locations closer to this location show up at the top of the list, sorted by distance. You also still get back a significant amount of remote locations, for a well balanced mix. Because you provided a focus point, Mapzen Search can compute distance from that point for each resulting feature.
 
-> * YMCA, Redfern, New South Wales [distance: 3.836]
+* YMCA, Redfern, New South Wales [distance: 3.836]
 * YMCA, St Ives (NSW), New South Wales [distance: 14.844]
 * YMCA, Epping (NSW), New South Wales [distance: 16.583]
 * YMCA, Revesby, New South Wales [distance: 21.335]
@@ -227,7 +226,7 @@ Now that you have seen how to use boundary and focus to narrow and sort your res
 
 Going back to the YMCA search you conducted with a focus around a point in Sydney, the results came back from distant parts of the world, as expected. But say you wanted to only see results from the country in which your focus point lies. You can combine that same focus point in Sydney with the country boundary of Australia like this.
 
-> [/v1/search?api_key={YOUR-KEY}&text=YMCA&___focus.point.lat=-33.856680&focus.point.lon=151.215281___](https://search.mapzen.com/v1/search?api_key=search-XXXXXXX&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281)
+> [/v1/search?api_key={YOUR-KEY}&text=YMCA&___focus.point.lat=-33.856680&focus.point.lon=151.215281___](https://search.mapzen.com/v1/search?api_key=search-hnopfLZ&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281)
 
 | parameter | value |
 | :--- | :--- |
@@ -239,7 +238,7 @@ Going back to the YMCA search you conducted with a focus around a point in Sydne
 
 The results below look different from the ones you saw before with only a focus point specified. These results are all from within Australia. You'll note the closest results show up at the top of the list, which is helped by the focus parameter.
 
-> * YMCA, Redfern, New South Wales [distance: 3.836]
+* YMCA, Redfern, New South Wales [distance: 3.836]
 * YMCA, St Ives (NSW), New South Wales [distance: 14.844]
 * YMCA, Epping (NSW), New South Wales [distance: 16.583]
 * YMCA, Revesby, New South Wales [distance: 21.335]
@@ -254,7 +253,7 @@ The results below look different from the ones you saw before with only a focus 
 
 If you are looking for the nearest YMCA locations, and are willing to travel no farther than 50 kilometers from your current location, you likely would want the results to be sorted by distance from current location to make your selection process easier. You can get this behavior by using `focus.point` in combination with `boundary.circle.*`. You can use the `focus.point.*` values as the `boundary.circle.lat` and `boundary.circle.lon`, and add the required `boundary.circle.radius` value in kilometers.
 
-> [/v1/search?api_key=search-XXXXXXX&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281&___boundary.circle.lat=-33.856680&boundary.circle.lon=151.215281&boundary.circle.radius=50___](https://search.mapzen.com/v1/search?api_key=search-XXXXXXX&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281&boundary.circle.lat=-33.856680&boundary.circle.lon=151.215281&boundary.circle.radius=50)
+> [/v1/search?api_key=search-hnopfLZ&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281&___boundary.circle.lat=-33.856680&boundary.circle.lon=151.215281&boundary.circle.radius=50___](https://search.mapzen.com/v1/search?api_key=search-hnopfLZ&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281&boundary.circle.lat=-33.856680&boundary.circle.lon=151.215281&boundary.circle.radius=50)
 
 | parameter | value |
 | :--- | :--- |
@@ -268,7 +267,7 @@ If you are looking for the nearest YMCA locations, and are willing to travel no 
 
 Looking at these results, they are all less than 50 kilometers away from the focus point:
 
-> * YMCA, Redfern, New South Wales [distance: 3.836]
+* YMCA, Redfern, New South Wales [distance: 3.836]
 * YMCA, St Ives (NSW), New South Wales [distance: 14.844]
 * YMCA, Epping (NSW), New South Wales [distance: 16.583]
 * YMCA, Revesby, New South Wales [distance: 21.335]
@@ -296,7 +295,7 @@ The search examples so far have returned a mix of results from all the data sour
 
 If you use the `sources` parameter, you can choose which of these data sources to include in your search. So if you're only interested in finding a YMCA in data from OpenAddresses, for example, you can build a query specifying that data source.
 
-> [/v1/search?api_key=search-XXXXXXX&text=YMCA&___sources=oa___](https://search.mapzen.com/v1/search?api_key=search-XXXXXXX&text=YMCA&sources=oa)
+> [/v1/search?api_key=search-hnopfLZ&text=YMCA&___sources=oa___](https://search.mapzen.com/v1/search?api_key=search-hnopfLZ&text=YMCA&sources=oa)
 
 | parameter | value |
 | :--- | :--- |
@@ -319,7 +318,7 @@ Because OpenAddresses is, as the name suggests, only address data, here's what y
 
 If you wanted to combine several data sources together, set `sources` to a comma separated list of desired source names. Note that the order of the comma separated values does not impact sorting order of the results; they are still sorted based on the linguistic match quality to `text` and distance from `focus`, if you specified one.
 
-> [/v1/search?api_key=search-XXXXXXX&text=YMCA&___sources=osm,gn___](https://search.mapzen.com/v1/search?api_key=search-XXXXXXX&text=YMCA&sources=oa)
+> [/v1/search?api_key=search-hnopfLZ&text=YMCA&___sources=osm,gn___](https://search.mapzen.com/v1/search?api_key=search-hnopfLZ&text=YMCA&sources=oa)
 
 | parameter | value |
 | :--- | :--- |
@@ -344,7 +343,7 @@ In Mapzen Search, place types are referred to as `layers`, ranging from fine to 
 |`neighbourhood`|social communities, neighbourhoods|
 |`coarse`|alias for simultaneously using `country`, `region`, `county`, `locality`, `localadmin`, and `neighbourhood`|
 
-> [/v1/search?api_key=search-XXXXXXX&text=YMCA&___layers=venue,address___](https://search.mapzen.com/v1/search?api_key=search-XXXXXXX&text=YMCA&layers=venue,address)
+> [/v1/search?api_key=search-hnopfLZ&text=YMCA&___layers=venue,address___](https://search.mapzen.com/v1/search?api_key=search-hnopfLZ&text=YMCA&layers=venue,address)
 
 | parameter | value |
 | :--- | :--- |


### PR DESCRIPTION
Fixes #108.

Following discussion with @migurski and in issue #108, I made a new GitHub account for use in documentation and created new keys. We can rotate these periodically or change their limits as needed. I will monitor the usage.

Some keys should still remain placeholders, so I did not do an automatic "replace all" in the files. I left the tutorial and the generic examples in Search enpoint, for example.

Other fixes:
- made all the links consistently formatted (some started with full URL, others v1)
- added bold formatting around certain parts of the URL to show specific capabilities being described
- made a few minor formatting or wording changes

There's likely a prettier way we can make these examples, but the key now is that they should all work.

(side note, I accidentally pushed to master, so had to make a revert and cherry-pick the commits back into my branch)