### PR TITLE
specifics about ES

### DIFF
--- a/installing.md
+++ b/installing.md
@@ -248,10 +248,16 @@ configure admin lookup and deduplication for OpenAddresses.
 Other than requiring Elasticsearch 1.7, nothing special in the Elasticsearch setup is required for
 Pelias, so please refer to the [official 1.7 install docs](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/setup.html).
 
+Newer versions of Elasticsearch are not supported. 
+
 Make sure Elasticsearch is running and connectable, and then you can continue with the Pelias
 specific setup and importing. Using a plugin like [head](https://mobz.github.io/elasticsearch-head/)
 or [Marvel](https://www.elastic.co/products/marvel) can help monitor Elasticsearch as you import
 data.
+
+If you're using a terminal, you can also search and/or monitor Elasticsearch using their [APIs.](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/api-conventions.html)
+
+**Note:** On large imports, Elasticsearch can be very sensitive to memory issues. Be sure to modify it's [heap size](https://www.elastic.co/guide/en/elasticsearch/guide/1.x/heap-sizing.html) from the default confiration to something more appropriate to your machine.  
 
 ### Set up the Elasticsearch Schema
 


### PR DESCRIPTION
including heap size info, 

Also minor quibble on line 112, the address_dedupe libarary currently used does *not* use libpostal as far as I can tell. I believe it uses the earlier address_normalize library, which has since been depreciated.