### PR TITLE
fix grammar and add leaflet link

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,5 +11,5 @@ Mapzen Search also enables the opposite workflow, known as [reverse geocoding](r
 - Autocomplete to give real-time result suggestions without having to type the whole location
 - Global coverage with prioritized local results
 - Open-source software using open data sources
-- Plug-in for embedding search in a Leaflet-based maps
+- Plug-in for embedding search in a [Leaflet-based](leafletjs.com) map
 - API with generous rate limits

--- a/index.md
+++ b/index.md
@@ -11,5 +11,5 @@ Mapzen Search also enables the opposite workflow, known as [reverse geocoding](r
 - Autocomplete to give real-time result suggestions without having to type the whole location
 - Global coverage with prioritized local results
 - Open-source software using open data sources
-- Plug-in for embedding search in a [Leaflet-based](leafletjs.com) map
+- Plug-in for embedding search in a [Leaflet-based](https://leafletjs.com/) map
 - API with generous rate limits


### PR DESCRIPTION
Original: "Plug-in for embedding search in a Leaflet-based maps". Map shouldn't be plural and I linked to Leaflet as its the first time its referenced in the docs