### PR TITLE
Add coordinate section to API response docs

### DIFF
--- a/response.md
+++ b/response.md
@@ -63,6 +63,10 @@ Additionally, [/reverse](reverse.md) queries will have a `distance` parameter, w
 
 ## Notable features
 
+## `coordinates`
+
+All results returned from Mapzen Search are points, and can be found in the `coordinates` array. Following the [GeoJSON specification](http://geojson.org/geojson-spec.html#positions), these coordinates are in **longitude, latitude** order.
+
 ### `gid`
 All places in Mapzen Search have a global identifier, known as a `gid`. Each matching record returned from a [/search](search.md), [/autocomplete](autocomplete.md), or [/reverse](reverse.md) geocoding request has a `gid` field.
 


### PR DESCRIPTION
These note that we use longitude, latitude order.

@rmglennon, @dianashk I was thinking of adding more about our plans to eventually return polygons in this section. Do you think that would fit in here? Update: I don't think it would. Would still love to hear thoughts though.

Fixes pelias/pelias#441