### PR TITLE
fix openaddresses sources typo

### DIFF
--- a/data-sources.md
+++ b/data-sources.md
@@ -6,7 +6,7 @@ Attribution is required for many of the Mapzen Search data providers. Some licen
 
 ## OpenAddresses
 
-`sources=openaddresses` | `sources=osm`
+`sources=openaddresses` | `sources=oa`
 
 Layers:
 


### PR DESCRIPTION
openaddresses sources shorthand was incorrectly indicated as `sources=osm`