### PR TITLE
Added no-tests Circle file to join the docs pipeline

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+machine:
+  python:
+    version: 2.7.10
+
+test:
+  override:
+    - echo "Fine, whatever."
+
+deployment:
+  release:
+    branch: "master"
+    commands:
+      - pip install 'Circle-Tickler == 1.0.1'
+      - tickle-circle mapzen mapzen-docs-generator master $CIRCLE_TOKEN


### PR DESCRIPTION
This change adds Pelias docs to Mapzen’s docs pipeline, so that successful master commits here trigger a fresh documentation publish process and no one needs to wait for docs to go live.

Part of https://github.com/mapzen/mapzen-docs-generator/issues/224.