### PR TITLE
Remove reference to JSON-formatting browser plug-ins

### DIFF
--- a/add-search-to-a-map.md
+++ b/add-search-to-a-map.md
@@ -270,7 +270,7 @@ Although you will not be using it in this tutorial, [\reverse](https://mapzen.co
 3. Click the Headers tab for more information about the request, including the full URL. For example, the URL might look something like `https://search.mapzen.com/v1/search?text=901%2012th%20avenue&focus.point.lat=47.61032944737081&focus.point.lon=-122.31800079345703&api_key=mapzen-xxxxxx`
 4. Paste this URL into a new browser tab to see the JSON response, which can be mapped.
 
-_Tip: You can install a plug-in for your browser to display JSON in a more formatted manner. For example, JSONView is a common extension that does this for Chrome. You can search the web store for your browser to find and install applicable products._
+_Tip: You can install a plug-in for your browser to display JSON in a more formatted manner. You can search the web store for your browser to find and install applicable products._
 
 ![Search endpoint query in the browser developer console](images/developer-console.png)
 

--- a/search.md
+++ b/search.md
@@ -34,7 +34,7 @@ Note the parameter values are set as follows:
 
 Clicking the link above will open a file containing the best matching results for the text `YMCA`. You will notice the data is in a computer-friendly format called [GeoJSON](http://geojson.org/), which may be hard for humans to read in some browsers.
 
-If you are having trouble seeing the JSON in your browser, you can install a browser extension for [Chrome](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc?hl=en) or [Firefox](https://addons.mozilla.org/en-us/firefox/addon/jsonview/) that will make it easier for you to read.
+You can install a plug-in for your browser to display JSON in a more formatted manner. You can search the web store for your browser to find and install applicable products.
 
 In the example above, you will find the name of each matched locations in a property named `'label'`. The top 10 labels returned were:
 


### PR DESCRIPTION
JSONView has been removed from the Chrome web store because of a security issue. 

Some folks are using JSON Formatter as a replacement, but it is also an older tool. Let's remove the specific product reference here.