### PR TITLE
Standardize API key language, add deprecation note to API keys page here

### DIFF
--- a/api-keys-rate-limits.md
+++ b/api-keys-rate-limits.md
@@ -1,10 +1,12 @@
 # API keys and rate limits
 
+_Note: This page is deprecated and has been removed from the documentation on https://mapzen.com/ as of May 2017. For more information, see the [Mapzen developer overview](https://mapzen.com/documentation/overview/)._
+
 ## Get started
 
-The Mapzen Search service requires an API key. In a request, you must append your own API key to the URL, following `&api_key=` at the end.
+The Mapzen Search service requires an API key. In a request, you must append your own API key to the URL, following `?api_key=`.
 
-See the [Mapzen developer overview](https://mapzen.com/documentation/overview/#mapzen-search) for more on API keys and rate limits.
+See the [Mapzen developer overview](https://mapzen.com/documentation/overview/) for more on API keys and rate limits.
 
 ## Caching to improve performance
 

--- a/http-status-codes.md
+++ b/http-status-codes.md
@@ -12,8 +12,3 @@ The following status codes are returned from the geocoding service:
 - `502 Bad Gateway`: Connection was lost to the Elasticsearch cluster.
 
 In all cases above, the response body will be valid GeoJSON.
-
-## Rate limiter
-The rate limiter returns the status codes `403 Forbidden` and `429 Too Many Requests`.
-
-See [API keys and rate limits](api-keys-rate-limits.md) for more information.


### PR DESCRIPTION
We have a central topic in the main documentation that should now be the source for all info about rate limits and API keys. 

This adds a deprecation note to the API keys page here, removes other references to rate limits and errors. 

This page no longer publishes to mapzen.com (see https://github.com/mapzen/documentation/pull/289) We can keep the source md file in GitHub for now, similar to other pages that have been deprecated.

Part of https://github.com/mapzen/documentation/issues/192