### PR TITLE
replace all github.io with mapzen.com base urls in example request links

### DIFF
--- a/autocomplete.md
+++ b/autocomplete.md
@@ -19,7 +19,7 @@ To focus your search based upon a geographical area, such as the center of the u
 From San Francisco:
 
 >
-[/v1/autocomplete?api_key=your-mapzen-api-key&__focus.point.lat=37.7&focus.point.lon=-122.4&text=union square__](https://mapzen.github.io/search-sandbox/?query=autocomplete&focus.point.lat=37.7&focus.point.lon=-122.4&text=union square)
+[/v1/autocomplete?api_key=your-mapzen-api-key&__focus.point.lat=37.7&focus.point.lon=-122.4&text=union square__](https://mapzen.com/search/explorer/?query=autocomplete&focus.point.lat=37.7&focus.point.lon=-122.4&text=union square)
 
 ```
 1)	Union Square, San Francisco County, CA
@@ -29,7 +29,7 @@ From San Francisco:
 From New York City:
 
 >
-[/v1/autocomplete?api_key=your-mapzen-api-key&__focus.point.lat=40.7&focus.point.lon=-73.9&text=union square__](https://mapzen.github.io/search-sandbox/?query=autocomplete&focus.point.lat=40.7&focus.point.lon=-73.9&text=union square)
+[/v1/autocomplete?api_key=your-mapzen-api-key&__focus.point.lat=40.7&focus.point.lon=-73.9&text=union square__](https://mapzen.com/search/explorer/?query=autocomplete&focus.point.lat=40.7&focus.point.lon=-73.9&text=union square)
 
 ```
 1)	Union Square, New York County, NY
@@ -38,7 +38,7 @@ From New York City:
 
 The `/autocomplete` endpoint can promote nearby results to the top of the list, while still allowing important matches from farther away to be visible. For example, searching `hard rock cafe` with a focus on Berlin:
 
-> [/v1/autocomplete?api_key=your-mapzen-api-key&__focus.point.lat=52.5&focus.point.lon=13.3&text=hard rock cafe__](https://mapzen.github.io/search-sandbox/?query=autocomplete&focus.point.lat=52.5&focus.point.lon=13.3&text=hard rock cafe)
+> [/v1/autocomplete?api_key=your-mapzen-api-key&__focus.point.lat=52.5&focus.point.lon=13.3&text=hard rock cafe__](https://mapzen.com/search/explorer/?query=autocomplete&focus.point.lat=52.5&focus.point.lon=13.3&text=hard rock cafe)
 
 with `focus.point` you will find the Berlin restaurant first:
 ```
@@ -65,7 +65,7 @@ The `sources` parameter allows you to specify from which data sources you'd like
 * `geonames` or `gn`
 * `whosonfirst` or `wof`
 
-> [/v1/autocomplete?api_key=your-mapzen-api-key&__sources=openaddresses__&text=pennsylvania](https://mapzen.github.io/search-sandbox/?query=autocomplete&sources=openaddresses&text=pennsylvania)
+> [/v1/autocomplete?api_key=your-mapzen-api-key&__sources=openaddresses__&text=pennsylvania](https://mapzen.com/search/explorer/?query=autocomplete&sources=openaddresses&text=pennsylvania)
 
 with `sources=openaddresses` you will only find addresses on Pennsylvania Ave or Street:
 ```
@@ -101,7 +101,7 @@ The type of record is referred to as its `layer`. All records are indexed into t
 |`neighbourhood`|social communities, neighbourhoods|
 |`coarse`|alias for simultaneously using all administrative layers (everything except `venue` and `address`)|
 
-> [/v1/autocomplete?api_key=your-mapzen-api-key&__layers=coarse__&text=starbuck](https://mapzen.github.io/search-sandbox/?query=autocomplete&layers=coarse&text=starbuck)
+> [/v1/autocomplete?api_key=your-mapzen-api-key&__layers=coarse__&text=starbuck](https://mapzen.com/search/explorer/?query=autocomplete&layers=coarse&text=starbuck)
 
 with `layers=coarse` you will see only administrative areas with names containing Starbuck
 

--- a/place.md
+++ b/place.md
@@ -6,7 +6,7 @@ The `/place` endpoint accepts Mapzen Search `gid` strings that get returned for 
 
 For example, this `/place` query looks up the Eiffel Tower in OpenStreetMap (OSM):
 
-> [/v1/place?api_key=your-mapzen-api-key&__ids=openstreetmap:venue:way:5013364__](https://mapzen.github.io/search-sandbox/?query=place&ids=openstreetmap:venue:way:5013364)
+> [/v1/place?api_key=your-mapzen-api-key&__ids=openstreetmap:venue:way:5013364__](https://mapzen.com/search/explorer/?query=place&ids=openstreetmap:venue:way:5013364)
 
 Note that you need an actual `gid` value to make a `/place` search. For example, if you search for an address and the result is [interpolated](addresses.md#address-interpolation), then there is no discrete `gid` to use for a `/place` search because interpolated results may be from multiple data sources.
 
@@ -14,7 +14,7 @@ Note that you need an actual `gid` value to make a `/place` search. For example,
 
 To search for more than one `/place` in a request, join multiple values together and separate them with a comma. For example, this `/place` query looks up the Eiffel Tower in OpenStreetMap and the borough of Manhattan in Who's on First:
 
-> [/v1/place?api_key=your-mapzen-api-key&__ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771__](https://mapzen.github.io/search-sandbox/?query=place&ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771)
+> [/v1/place?api_key=your-mapzen-api-key&__ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771__](https://mapzen.com/search/explorer/?query=place&ids=openstreetmap:venue:way:5013364,whosonfirst:borough:421205771)
 
 The results are returned in the order requested.
 

--- a/response.md
+++ b/response.md
@@ -107,8 +107,8 @@ By default, Mapzen Search results 10 places, unless otherwise specified. If you 
 | `text` | YMCA |
 | `size` | 1 |
 
-> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___size=1___](https://mapzen.github.io/search-sandbox/?query=search&text=YMCA&size=1)
+> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___size=1___](https://mapzen.com/search/explorer/?query=search&text=YMCA&size=1)
 
 If you want 25 results, you can build the query where `size` is 25.
 
-> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___size=25___](https://mapzen.github.io/search-sandbox/?query=search&text=YMCA&size=25)
+> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___size=25___](https://mapzen.com/search/explorer/?query=search&text=YMCA&size=25)

--- a/reverse.md
+++ b/reverse.md
@@ -14,7 +14,7 @@ With reverse geocoding with Mapzen Search, you can look up all sorts of informat
 
 To get started with reverse geocoding, you need a latitude, longitude pair in decimal degrees specified with the parameters `point.lat` and `point.lon`, respectively.  For example, the Eiffel Tower in Paris, France, is located at `48.858268,2.294471`. The reverse geocode query for this would be:
 
->[/v1/reverse?api_key=your-mapzen-api-key&___point.lat=48.858268___&___point.lon=2.294471___](https://mapzen.github.io/search-sandbox/?query=reverse&point.lat=48.858268&point.lon=2.294471)
+>[/v1/reverse?api_key=your-mapzen-api-key&___point.lat=48.858268___&___point.lon=2.294471___](https://mapzen.com/search/explorer/?query=reverse&point.lat=48.858268&point.lon=2.294471)
 
 The output is the standard GeoJSON format.
 
@@ -36,7 +36,7 @@ Parameter | Type | Required | Default | Example
 
 A basic parameter for filtering is `size`, which is used to limit the number of results returned. In the earlier request that returned the Eiffel Tower (or 'Tour Eiffel', to be exact), notice that other results were returned including "Bureau de Gustave Eiffel" (a museum) and "Le Jules Verne" (a restaurant). To limit a reverse geocode to only the first result, pass the `size` parameter:
 
->[/v1/reverse?api_key=your-mapzen-api-key&point.lat=48.858268&point.lon=2.294471&___size=1___](https://mapzen.github.io/search-sandbox/?query=reverse&point.lat=48.858268&point.lon=2.294471&size=1)
+>[/v1/reverse?api_key=your-mapzen-api-key&point.lat=48.858268&point.lon=2.294471&___size=1___](https://mapzen.com/search/explorer/?query=reverse&point.lat=48.858268&point.lon=2.294471&size=1)
 
 The default value for `size` is `10` and the maximum value is `40`. Specifying a value greater than `40` will override to `40` and return a warning in the response metadata.
 
@@ -51,13 +51,13 @@ By default, reverse geocoding returns results from any [data source](data-source
 | [Who's on First](https://whosonfirst.mapzen.com) | `whosonfirst` | `wof` |
 | [GeoNames](http://www.geonames.org/) | `geonames` | `gn` |
 
->[/v1/reverse?api_key=your-mapzen-api-key&point.lat=48.858268&point.lon=2.294471&___sources=osm___](https://mapzen.github.io/search-sandbox/?query=reverse&point.lat=48.858268&point.lon=2.294471&sources=osm)
+>[/v1/reverse?api_key=your-mapzen-api-key&point.lat=48.858268&point.lon=2.294471&___sources=osm___](https://mapzen.com/search/explorer/?query=reverse&point.lat=48.858268&point.lon=2.294471&sources=osm)
 
 ### Filter by layers (data type)
 
 Without specifying further, reverse geocoding doesn't restrict results to a particular type (street, venue, neighbourhood, and so on).  If your application is only concerned with, say, which city a latitude, longitude is closest to, then use the `layers` parameter.  For example, the following request returns only results that are localities (cities and towns):
 
->[/v1/reverse?api_key=your-mapzen-api-key&point.lat=48.858268&point.lon=2.294471&___layers=locality___](https://mapzen.github.io/search-sandbox/?query=reverse&point.lat=48.858268&point.lon=2.294471&layers=locality)
+>[/v1/reverse?api_key=your-mapzen-api-key&point.lat=48.858268&point.lon=2.294471&___layers=locality___](https://mapzen.com/search/explorer/?query=reverse&point.lat=48.858268&point.lon=2.294471&layers=locality)
 
 Here are all the supported layers and their meanings.
 
@@ -81,7 +81,7 @@ Here are all the supported layers and their meanings.
 
 If you are performing a reverse geocode near a country boundary, and are only interested in results from one country and not the other, you can specify a country code. You can set the `boundary.country` parameter value to the alpha-2 or alpha-3 [ISO-3166 country code](https://en.wikipedia.org/wiki/ISO_3166-1). For example, the latitude,longitude pair `47.270521,9.530846` is on the boundary of Austria, Liechtenstein, and Switzerland. Without specifying a `boundary.country`, the first 10 results returned may come from all three countries. By including `boundary.country=LIE`, all 10 results will be from Liechtenstein. Here's the request in action:
 
->[/v1/reverse?api_key=your-mapzen-api-key&point.lat=47.270521&point.lon=9.530846&___boundary.country=LIE___](https://mapzen.github.io/search-sandbox/?query=reverse&point.lat=47.270521&point.lon=9.530846&boundary.country=LIE)
+>[/v1/reverse?api_key=your-mapzen-api-key&point.lat=47.270521&point.lon=9.530846&___boundary.country=LIE___](https://mapzen.com/search/explorer/?query=reverse&point.lat=47.270521&point.lon=9.530846&boundary.country=LIE)
 
 Note that `UK` is not a valid ISO 3166-1 alpha-2 country code.
 
@@ -103,16 +103,16 @@ Distance from `point.lat`/`point.lon` | Confidence score
 This section shows how the various parameters can be combined to form complex use cases.
 
 * All results near the Tower of London
->[/v1/reverse?api_key=your-mapzen-api-key&point.lat=51.5081124&point.lon=-0.0759493](https://mapzen.github.io/search-sandbox/?query=reverse&point.lat=51.5081124&point.lon=-0.0759493)
+>[/v1/reverse?api_key=your-mapzen-api-key&point.lat=51.5081124&point.lon=-0.0759493](https://mapzen.com/search/explorer/?query=reverse&point.lat=51.5081124&point.lon=-0.0759493)
 
 * Only OpenStreetMap results near the Tower of London
->[/v1/reverse?api_key=your-mapzen-api-key&point.lat=51.5081124&point.lon=-0.0759493&sources=osm](https://mapzen.github.io/search-sandbox/?query=reverse&point.lat=51.5081124&point.lon=-0.0759493&sources=osm)
+>[/v1/reverse?api_key=your-mapzen-api-key&point.lat=51.5081124&point.lon=-0.0759493&sources=osm](https://mapzen.com/search/explorer/?query=reverse&point.lat=51.5081124&point.lon=-0.0759493&sources=osm)
 
 * Only street addresses near the Tower of London
->[/v1/reverse?api_key=your-mapzen-api-key&point.lat=51.5081124&point.lon=-0.0759493&layers=address](https://mapzen.github.io/search-sandbox/?query=reverse&point.lat=51.5081124&point.lon=-0.0759493&layers=address)
+>[/v1/reverse?api_key=your-mapzen-api-key&point.lat=51.5081124&point.lon=-0.0759493&layers=address](https://mapzen.com/search/explorer/?query=reverse&point.lat=51.5081124&point.lon=-0.0759493&layers=address)
 
 * Only OpenStreetMap street addresses near the Tower of London
->[/v1/reverse?api_key=your-mapzen-api-key&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm](https://mapzen.github.io/search-sandbox/?query=reverse&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm)
+>[/v1/reverse?api_key=your-mapzen-api-key&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm](https://mapzen.com/search/explorer/?query=reverse&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm)
 
 * Only the first OpenStreetMap address near the Tower of London
->[/v1/reverse?api_key=your-mapzen-api-key&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm&size=1](https://mapzen.github.io/search-sandbox/?query=reverse&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm&size=1)
+>[/v1/reverse?api_key=your-mapzen-api-key&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm&size=1](https://mapzen.com/search/explorer/?query=reverse&point.lat=51.5081124&point.lon=-0.0759493&layers=address&sources=osm&size=1)

--- a/search.md
+++ b/search.md
@@ -27,7 +27,7 @@ In the simplest search, you can provide only one parameter, the text you want to
 
 For example, if you want to find a [YMCA](https://en.wikipedia.org/wiki/YMCA) facility, here's what you'd need to append to the base URL of the service, `search.mapzen.com`.
 
-> [/v1/search?api_key=your-mapzen-api-key&___text=YMCA___](https://mapzen.github.io/search-sandbox/?query=search&text=YMCA)
+> [/v1/search?api_key=your-mapzen-api-key&___text=YMCA___](https://mapzen.com/search/explorer/?query=search&text=YMCA)
 
 Note the parameter values are set as follows:
 
@@ -55,7 +55,7 @@ In the example above, you will find the name of each matched locations in a prop
 
 Spelling matters, but not capitalization when performing a query with Mapzen Search. You can type `ymca`, `YMCA`, or even `yMcA`. See for yourself by comparing the results of the earlier search to the following:
 
-> [/v1/search?api_key=your-mapzen-api-key&___text=yMcA___](https://mapzen.github.io/search-sandbox/?query=search&text=yMcA)
+> [/v1/search?api_key=your-mapzen-api-key&___text=yMcA___](https://mapzen.com/search/explorer/?query=search&text=yMcA)
 
 Note that the results are spread out throughout the world because you have not given your current location or provided any other geographic context in which to search.
 
@@ -88,11 +88,11 @@ By default, Mapzen Search results 10 places, unless otherwise specified. If you 
 | `text` | YMCA |
 | `size` | 1 |
 
-> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___size=1___](https://mapzen.github.io/search-sandbox/?query=search&text=YMCA&size=1)
+> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___size=1___](https://mapzen.com/search/explorer/?query=search&text=YMCA&size=1)
 
 If you want 25 results, you can build the query where `size` is 25.
 
-> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___size=25___](https://mapzen.github.io/search-sandbox/?query=search&text=YMCA&size=25)
+> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___size=25___](https://mapzen.com/search/explorer/?query=search&text=YMCA&size=25)
 
 ## Narrow your search
 
@@ -106,7 +106,7 @@ Sometimes your work might require that all the search results be from a particul
 
 Now, you want to search for YMCA again, but this time only in Great Britain. To do this, you will need to know that the alpha-3 code for Great Britain is GBR and set the parameters like this:
 
-> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___boundary.country=GBR___](https://mapzen.github.io/search-sandbox/?query=search&text=YMCA&boundary.country=GBR)
+> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___boundary.country=GBR___](https://mapzen.com/search/explorer/?query=search&text=YMCA&boundary.country=GBR)
 
 | parameter | value |
 | :--- | :--- |
@@ -129,7 +129,7 @@ Note that all the results are within Great Britain:
 
 If you try the same search request with different country codes, the results change to show YMCA locations within this region.
 
-> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___boundary.country=USA___](https://mapzen.github.io/search-sandbox/?query=search&text=YMCA&boundary.country=USA)
+> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___boundary.country=USA___](https://mapzen.com/search/explorer/?query=search&text=YMCA&boundary.country=USA)
 
 Results in the United States:
 
@@ -154,7 +154,7 @@ For example, to find a YMCA within the state of Texas, you can set the `boundary
 
 Tip: You can look up a bounding box for a known region with this [web tool](http://boundingbox.klokantech.com/).
 
-> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___boundary.rect.min_lat=25.84&boundary.rect.min_lon=-106.65&boundary.rect.max_lat=36.5&boundary.rect.max_lon=-93.51___](https://mapzen.github.io/search-sandbox/?query=search&text=YMCA&boundary.rect.min_lat=25.84&boundary.rect.min_lon=-106.65&boundary.rect.max_lat=36.5&boundary.rect.max_lon=-93.51)
+> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___boundary.rect.min_lat=25.84&boundary.rect.min_lon=-106.65&boundary.rect.max_lat=36.5&boundary.rect.max_lon=-93.51___](https://mapzen.com/search/explorer/?query=search&text=YMCA&boundary.rect.min_lat=25.84&boundary.rect.min_lon=-106.65&boundary.rect.max_lat=36.5&boundary.rect.max_lon=-93.51)
 
 | parameter | value |
 | :--- | :--- |
@@ -184,7 +184,7 @@ Sometimes you don't have a rectangle to work with, but rather you have a point o
 
 In this example, you want to find all YMCA locations within a 35-kilometer radius of a location in Ontario, Canada. This time, you can use the `boundary.circle.*` parameter group, where `boundary.circle.lat` and `boundary.circle.lon` is your location in Ontario and `boundary.circle.radius` is the acceptable distance from that location. Note that the `boundary.circle.radius` parameter is always specified in kilometers.
 
-> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&__boundary.circle.lon=-79.186484&boundary.circle.lat=43.818156&boundary.circle.radius=35__](https://mapzen.github.io/search-sandbox/?query=search&text=YMCA&boundary.circle.lon=-79.186484&boundary.circle.lat=43.818156&boundary.circle.radius=35)
+> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&__boundary.circle.lon=-79.186484&boundary.circle.lat=43.818156&boundary.circle.radius=35__](https://mapzen.com/search/explorer/?query=search&text=YMCA&boundary.circle.lon=-79.186484&boundary.circle.lat=43.818156&boundary.circle.radius=35)
 
 | parameter | value |
 | :--- | :--- |
@@ -220,7 +220,7 @@ By specifying a `focus.point`, nearby places will be scored higher depending on 
 
 To find YMCA again, but this time near a specific coordinate location (representing the Sydney Opera House) in Sydney, Australia, use `focus.point`.
 
-> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___focus.point.lat=-33.856680&focus.point.lon=151.215281___](https://mapzen.github.io/search-sandbox/?query=search&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281)
+> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___focus.point.lat=-33.856680&focus.point.lon=151.215281___](https://mapzen.com/search/explorer/?query=search&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281)
 
 | parameter | value |
 | :--- | :--- |
@@ -250,7 +250,7 @@ Now that you have seen how to use boundary and focus to narrow and sort your res
 
 Going back to the YMCA search you conducted with a focus around a point in Sydney, the results came back from distant parts of the world, as expected. But say you wanted to only see results from the country in which your focus point lies. You can combine that same focus point in Sydney with the country boundary of Australia like this.
 
-> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___focus.point.lat=-33.856680&focus.point.lon=151.215281___](https://mapzen.github.io/search-sandbox/?query=search&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281)
+> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___focus.point.lat=-33.856680&focus.point.lon=151.215281___](https://mapzen.com/search/explorer/?query=search&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281)
 
 | parameter | value |
 | :--- | :--- |
@@ -277,7 +277,7 @@ The results below look different from the ones you saw before with only a focus 
 
 If you are looking for the nearest YMCA locations, and are willing to travel no farther than 50 kilometers from your current location, you likely would want the results to be sorted by distance from current location to make your selection process easier. You can get this behavior by using `focus.point` in combination with `boundary.circle.*`. You can use the `focus.point.*` values as the `boundary.circle.lat` and `boundary.circle.lon`, and add the required `boundary.circle.radius` value in kilometers.
 
-> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281&___boundary.circle.lat=-33.856680&boundary.circle.lon=151.215281&boundary.circle.radius=50___](https://mapzen.github.io/search-sandbox/?query=search&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281&boundary.circle.lat=-33.856680&boundary.circle.lon=151.215281&boundary.circle.radius=50)
+> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281&___boundary.circle.lat=-33.856680&boundary.circle.lon=151.215281&boundary.circle.radius=50___](https://mapzen.com/search/explorer/?query=search&text=YMCA&focus.point.lat=-33.856680&focus.point.lon=151.215281&boundary.circle.lat=-33.856680&boundary.circle.lon=151.215281&boundary.circle.radius=50)
 
 | parameter | value |
 | :--- | :--- |
@@ -319,7 +319,7 @@ The search examples so far have returned a mix of results from all the data sour
 
 If you use the `sources` parameter, you can choose which of these data sources to include in your search. So if you're only interested in finding a YMCA in data from OpenAddresses, for example, you can build a query specifying that data source.
 
-> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___sources=oa___](https://mapzen.github.io/search-sandbox/?query=search&text=YMCA&sources=oa)
+> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___sources=oa___](https://mapzen.com/search/explorer/?query=search&text=YMCA&sources=oa)
 
 | parameter | value |
 | :--- | :--- |
@@ -342,7 +342,7 @@ Because OpenAddresses is, as the name suggests, only address data, here's what y
 
 If you wanted to combine several data sources together, set `sources` to a comma separated list of desired source names. Note that the order of the comma separated values does not impact sorting order of the results; they are still sorted based on the linguistic match quality to `text` and distance from `focus`, if you specified one.
 
-> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___sources=osm,gn___](https://mapzen.github.io/search-sandbox/?query=search&text=YMCA&sources=oa)
+> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___sources=osm,gn___](https://mapzen.com/search/explorer/?query=search&text=YMCA&sources=oa)
 
 | parameter | value |
 | :--- | :--- |
@@ -371,7 +371,7 @@ In Mapzen Search, place types are referred to as `layers`, ranging from fine to 
 |`country`|places that issue passports, nations, nation-states|
 |`coarse`|alias for simultaneously using all administrative layers (everything except `venue` and `address`)|
 
-> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___layers=venue,address___](https://mapzen.github.io/search-sandbox/?query=search&text=YMCA&layers=venue,address)
+> [/v1/search?api_key=your-mapzen-api-key&text=YMCA&___layers=venue,address___](https://mapzen.com/search/explorer/?query=search&text=YMCA&layers=venue,address)
 
 | parameter | value |
 | :--- | :--- |

--- a/structured-geocoding.md
+++ b/structured-geocoding.md
@@ -46,9 +46,9 @@ The `address` parameter can contain a full address with house number or only a s
 
 _Examples_
 
-* [201 Spear Street](https://mapzen.github.io/search-sandbox/?query=search/structured&address=201 Spear Street&locality=San Francisco&region=CA)
-* [Rue de Rivoli](https://mapzen.github.io/search-sandbox/?query=search/structured&address=Rue de Rivoli&locality=Paris&region=France)
-* [Přílucká 1](https://mapzen.github.io/search-sandbox/?query=search/structured&address=1 Přílucká&locality=Želechovice nad Dřevnicí)
+* [201 Spear Street](https://mapzen.com/search/explorer/?query=search/structured&address=201 Spear Street&locality=San Francisco&region=CA)
+* [Rue de Rivoli](https://mapzen.com/search/explorer/?query=search/structured&address=Rue de Rivoli&locality=Paris&region=France)
+* [Přílucká 1](https://mapzen.com/search/explorer/?query=search/structured&address=1 Přílucká&locality=Želechovice nad Dřevnicí)
 
 ### neighbourhood
 
@@ -56,9 +56,9 @@ _Examples_
 
 _Examples_
 
-* [Notting Hill](https://mapzen.github.io/search-sandbox/?query=search/structured&neighbourhood=Notting Hill&locality=London) in London
-* [Flatiron District](https://mapzen.github.io/search-sandbox/?query=search/structured&neighbourhood=Flatiron District&borough=Manhattan) in Manhattan
-* [Le Marais](https://mapzen.github.io/search-sandbox/?query=search/structured&neighbourhood=Le Marais&locality=Paris) in Paris
+* [Notting Hill](https://mapzen.com/search/explorer/?query=search/structured&neighbourhood=Notting Hill&locality=London) in London
+* [Flatiron District](https://mapzen.com/search/explorer/?query=search/structured&neighbourhood=Flatiron District&borough=Manhattan) in Manhattan
+* [Le Marais](https://mapzen.com/search/explorer/?query=search/structured&neighbourhood=Le Marais&locality=Paris) in Paris
 
 ### borough
 
@@ -66,8 +66,8 @@ _Examples_
 
 _Examples_
 
-* [Manhattan](https://mapzen.github.io/search-sandbox/?query=search/structured&borough=Manhattan&locality=New York)
-* [Iztapalapa](https://mapzen.github.io/search-sandbox/?query=search/structured&borough=Iztapalapa&locality=Mexico City)
+* [Manhattan](https://mapzen.com/search/explorer/?query=search/structured&borough=Manhattan&locality=New York)
+* [Iztapalapa](https://mapzen.com/search/explorer/?query=search/structured&borough=Iztapalapa&locality=Mexico City)
 
 A structured geocoding request for `/v1/search/structured?locality=Manhattan&region=NY`, returns boroughs along with localities.  
 
@@ -77,9 +77,9 @@ A structured geocoding request for `/v1/search/structured?locality=Manhattan&reg
 
 _Examples_
 
-* [Bangkok](https://mapzen.github.io/search-sandbox/?query=search/structured&locality=Bangkok&country=Thailand)
-* [Caracas](https://mapzen.github.io/search-sandbox/?query=search/structured&locality=Caracas&country=Venezuela)
-* [Truth or Consequences](https://mapzen.github.io/search-sandbox/?query=search/structured&locality=Truth or Consequences&region=NM) in New Mexico
+* [Bangkok](https://mapzen.com/search/explorer/?query=search/structured&locality=Bangkok&country=Thailand)
+* [Caracas](https://mapzen.com/search/explorer/?query=search/structured&locality=Caracas&country=Venezuela)
+* [Truth or Consequences](https://mapzen.com/search/explorer/?query=search/structured&locality=Truth or Consequences&region=NM) in New Mexico
 
 ### county
 
@@ -87,9 +87,9 @@ _Examples_
 
 _Examples_
 
-* [Bucks](https://mapzen.github.io/search-sandbox/?query=search/structured&county=Bucks&region=PA) in Pennsylvania
-* [Maui](https://mapzen.github.io/search-sandbox/?query=search/structured&county=Maui&region=HI)
-* [Alb-Donau-Kreis](https://mapzen.github.io/search-sandbox/?query=search/structured&county=Alb-Donau-Kreis&country=DEU) in Germany
+* [Bucks](https://mapzen.com/search/explorer/?query=search/structured&county=Bucks&region=PA) in Pennsylvania
+* [Maui](https://mapzen.com/search/explorer/?query=search/structured&county=Maui&region=HI)
+* [Alb-Donau-Kreis](https://mapzen.com/search/explorer/?query=search/structured&county=Alb-Donau-Kreis&country=DEU) in Germany
 
 Counties are not as commonly used in geocoding as localities, but can be useful when attempting to disambiguate between localities. For instance, there are three cities named Red Lion in Pennsylvania but only one in each of three counties. Specifying a county disambiguates this list to a single result.  
 
@@ -99,9 +99,9 @@ Counties are not as commonly used in geocoding as localities, but can be useful 
 
 _Examples_
 
-* [Delaware](https://mapzen.github.io/search-sandbox/?query=search/structured&region=Delaware)
-* [Ontario](https://mapzen.github.io/search-sandbox/?query=search/structured&region=Ontario)
-* [Ardennes](https://mapzen.github.io/search-sandbox/?query=search/structured&region=Ardennes)
+* [Delaware](https://mapzen.com/search/explorer/?query=search/structured&region=Delaware)
+* [Ontario](https://mapzen.com/search/explorer/?query=search/structured&region=Ontario)
+* [Ardennes](https://mapzen.com/search/explorer/?query=search/structured&region=Ardennes)
 
 Regions in the United States have [common abbreviations](https://en.wikipedia.org/wiki/List_of_U.S._state_abbreviations), such as PA for [Pennsylvania](https://whosonfirst.mapzen.com/spelunker/id/85688481/) and NM for [New Mexico](https://whosonfirst.mapzen.com/spelunker/id/85688493/).  The `region` parameter can be a full name or abbreviation, so specifying `/v1/search/structured?region=NM` is functionality equivalent to `/v1/search/structured?region=New Mexico`.  
 
@@ -115,7 +115,7 @@ _Examples_
 * [CV23 9SL](https://whosonfirst.mapzen.com/spelunker/id/454261459/)
 * [5439171](https://whosonfirst.mapzen.com/spelunker/id/538904173/)
 
-Keep in mind that you can search for `postalcode` exclusively. So requests like [/v1/search/structured?postalcode=87801]( https://mapzen.github.io/search-sandbox/?query=search/structured&postalcode=87801) will return matching postalcode records.
+Keep in mind that you can search for `postalcode` exclusively. So requests like [/v1/search/structured?postalcode=87801]( https://mapzen.com/search/explorer/?query=search/structured&postalcode=87801) will return matching postalcode records.
 
 ### country
 
@@ -123,9 +123,9 @@ Keep in mind that you can search for `postalcode` exclusively. So requests like 
 
 _Examples_
 
-* [Liechtenstein](https://mapzen.github.io/search-sandbox/?query=search/structured&country=Liechtenstein)
-* [CMR](https://mapzen.github.io/search-sandbox/?query=search/structured&country=CMR) ([Cameroon](https://whosonfirst.mapzen.com/spelunker/id/85632245/))
-* [Bermuda](https://mapzen.github.io/search-sandbox/?query=search/structured&country=Bermuda)
+* [Liechtenstein](https://mapzen.com/search/explorer/?query=search/structured&country=Liechtenstein)
+* [CMR](https://mapzen.com/search/explorer/?query=search/structured&country=CMR) ([Cameroon](https://whosonfirst.mapzen.com/spelunker/id/85632245/))
+* [Bermuda](https://mapzen.com/search/explorer/?query=search/structured&country=Bermuda)
 
 ## Who's On First layer mappings reference
 


### PR DESCRIPTION
This updates the base URLs for https://mapzen.github.io/search-sandbox with https://mapzen.com/search/explorer in the example links to reflect the sandbox's new home on mapzen.com.