### PR TITLE
Add boundary.circle parameters for reverse

### DIFF
--- a/reverse.md
+++ b/reverse.md
@@ -27,6 +27,9 @@ Parameter | Type | Required | Default | Example
 `api_key` | string | yes | none | [get yours here](https://mapzen.com/developers)
 `point.lat` | floating point number | yes | none | `48.858268`
 `point.lon` | floating point number | yes | none | `2.294471`
+`boundary.circle.lat` | floating point number | no | none | `43.818156` 
+`boundary.circle.lon` | floating point number | no | none | `-79.186484` 
+`boundary.circle.radius` | floating point number | no | 1 | `35` 
 `size` | integer | no | `10` | `3`
 `layers` | comma-delimited string array | no | none (all layers) | `address,locality`
 `sources` | comma-delimited string array | no | none (all sources) | `oa,gn`


### PR DESCRIPTION
fixes #196 

Copies these from search and adds in the default for boundary.circle.radius default from https://github.com/pelias/api/blob/master/query/reverse_defaults.js.

Are boundary.circle.lat and lon are actually user-specifiable for reverse? Perhaps boundary.circle.lat and lon are always going to be point.lat and point.lon and cannot be changed in a query because there is only one radius/no options for overlapping circles?

If so, I'll remove boundary.circle.lat/lon from here.

Sample result:
      "point.lat": 48.858268,
      "point.lon": 2.294471,
      "boundary.circle.radius": 1,
      "boundary.circle.lat": 48.858268, <-- these seem fall back to point.lat, lon, if I've specified something else for them
      "boundary.circle.lon": 2.294471,