### PR TITLE
Shorten API key example text to avoid wrapping

### DIFF
--- a/search.md
+++ b/search.md
@@ -9,8 +9,8 @@ Making the leap from text to coordinates is an intricate and challenging process
 All Mapzen Search requests share the same format:
 
 ```
-   https://search.mapzen.com/v1/search?text=London&api_key=your-mapzen-api-key
-   \___/   \_______________/\__/\_____/\__________/\_________________________/
+   https://search.mapzen.com/v1/search?text=London&api_key=your-api-key
+   \___/   \_______________/\__/\_____/\__________/\___________________/
      |            |          /     |        |                |
   scheme       domain   version  path     query     authentication token
 ```


### PR DESCRIPTION
This rolls back this commit, with a slight modification https://github.com/pelias/pelias-doc/commit/7a4c172b20e02b2a58a8a763983756c46d97aac2

in the production docs, it looks like this 

![image](https://cloud.githubusercontent.com/assets/4380498/26807238/38c4528c-4a0a-11e7-8abc-390967d13b57.png)

(we shouldn't use mapzen-(anything) in the samples because they might squeak through as legit...)

