### PR TITLE
remove boundary.circle.lat and lon for reverse

### DIFF
--- a/reverse.md
+++ b/reverse.md
@@ -27,8 +27,6 @@ Parameter | Type | Required | Default | Example
 `api_key` | string | yes | none | [get yours here](https://mapzen.com/developers)
 `point.lat` | floating point number | yes | none | `48.858268`
 `point.lon` | floating point number | yes | none | `2.294471`
-`boundary.circle.lat` | floating point number | no | none | `43.818156` 
-`boundary.circle.lon` | floating point number | no | none | `-79.186484` 
 `boundary.circle.radius` | floating point number | no | 1 | `35` 
 `size` | integer | no | `10` | `3`
 `layers` | comma-delimited string array | no | none (all layers) | `address,locality`


### PR DESCRIPTION
I wasn't sure if boundary.circle.lat and lon were used with /reverse when I submitted the previous edits: https://github.com/pelias/pelias-doc/pull/197

Using them now gives an error message, so I'm removing these parameters for sure.

`[WARNING] boundary.circle.lat/boundary.circle.lon are currently unsupported`