### PR TITLE
changing geojson spec link to current site

### DIFF
--- a/response.md
+++ b/response.md
@@ -2,7 +2,7 @@
 
 When requesting results from Mapzen Search, you will always get back GeoJSON results, unless something goes terribly wrong, in which case you'll get an error message.
 
-  Tip: You can go to http://geojson.org/geojson-spec.html to learn more about the GeoJSON data format specification.
+  Tip: You can go to https://tools.ietf.org/html/rfc7946 to learn more about the GeoJSON data format specification.
 
 The top-level structure to every response looks like this:
 


### PR DESCRIPTION
The current page the docs link to for the geojson spec http://geojson.org/geojson-spec.html says it is obsolete and points to https://tools.ietf.org/html/rfc7946. 

This updates the link to the current site.