### PR TITLE
Update data-sources page for OpenAddresses share-alike data

### DIFF
--- a/data-sources.md
+++ b/data-sources.md
@@ -16,7 +16,8 @@ Layers:
 
 OpenAddresses is by far the largest dataset by number of records used by Mapzen Search. Even though it only contains address data (as in no building names or other metadata), it's a great resource for global geocoding.
 
-Many of the sources used in OpenAddresses require [attribution](https://mapzen.com/rights/). Mapzen Search _does not_ import OpenAddresses sources marked as Share-Alike by the OpenAddresses project.
+The license for each individual source within OpenAddresses differs. Many of the sources require [attribution](https://mapzen.com/rights/), and many others have a share-alike clause.
+*Note:* Mapzen Search does _not_ currently return license information directly, but the license and attribution requirements for each source within OpenAddresses can be determined from the machine-readable [state.txt](http://results.openaddresses.io/state.txt) file published on the OpenAddresses website.
 
 ## Who's on First
 


### PR DESCRIPTION
Now that we plan to import share-alike data, we need to tell users where
they can find out which OpenAddresses data is actually share alike. The
state.txt file on the OpenAddresses website has that information.